### PR TITLE
encode review. Bug Corrections

### DIFF
--- a/lib/logstash/codecs/avro_schema_registry.rb
+++ b/lib/logstash/codecs/avro_schema_registry.rb
@@ -1,6 +1,5 @@
 # encoding: utf-8
 require "avro"
-require "open-uri"
 require "schema_registry"
 require "schema_registry/client"
 require "logstash/codecs/base"
@@ -8,7 +7,6 @@ require "logstash/namespace"
 require "logstash/event"
 require "logstash/timestamp"
 require "logstash/util"
-require "base64"
 
 MAGIC_BYTE = 0
 
@@ -18,37 +16,25 @@ MAGIC_BYTE = 0
 # Avro datums, as well as deserializing Avro datums into
 # Logstash events.
 #
+# ==== Encoding
 #
-# ==== Decoding (input)
+# This codec currently does not encode. This might be added later.
+#
+#
+# ==== Decoding
 #
 # This codec is for deserializing individual Avro records. It looks up
 # the associated avro schema from a Confluent schema registry.
 # (https://github.com/confluentinc/schema-registry)
 #
-# When this codec is used on the input, only the ``endpoint`` option is required.
-#
-# ==== Encoding (output)
-#
-# This codec uses the Confluent schema registry to register a schema and
-# encode the data in Avro using schema_id lookups.
-#
-# You can pass several options:
-# - ``endpoint`` is always required.
-# - If ``schema_id`` is provided, no other options are required.
-# - Otherwise, ``subject_name`` is required.
-# - If ``schema_version`` is provided, the schema will be looked up in the registry.
-# - Otherwise, a JSON schema is loaded from either ``schema_uri``, or ``schema_string``
-# - If ``check_compatibility`` is true, always check compatibility.
-# - If ``register_schema`` is true, register the JSON schema if it does not exist.
 #
 # ==== Usage
-# Example usage with Kafka input and output.
+# Example usage with Kafka input.
 #
 # [source,ruby]
 # ----------------------------------
 # input {
 #   kafka {
-#     ...
 #     codec => avro_schema_registry {
 #       endpoint => "http://schemas.example.com"
 #     }
@@ -58,97 +44,29 @@ MAGIC_BYTE = 0
 #   ...
 # }
 # output {
-#   kafka {
-#     ...
-#     codec => avro_schema_registry {
-#       endpoint => "http://schemas.example.com"
-#       subject_name => "my_kafka_subject_name"
-#       schema_uri => "/app/my_kafka_subject.avsc"
-#       register_schema => true
-#     }
-#   }
+#   ...
 # }
 # ----------------------------------
 class LogStash::Codecs::AvroSchemaRegistry < LogStash::Codecs::Base
   config_name "avro_schema_registry"
-  
-  EXCLUDE_ALWAYS = [ "@timestamp", "@version" ]
 
   # schema registry endpoint and credentials
   config :endpoint, :validate => :string, :required => true
   config :username, :validate => :string, :default => nil
   config :password, :validate => :string, :default => nil
-
   config :schema_id, :validate => :number, :default => nil
-  config :subject_name, :validate => :string, :default => nil
-  config :schema_version, :validate => :number, :default => nil
-  config :schema_uri, :validate => :string, :default => nil
-  config :schema_string, :validate => :string, :default => nil
-  config :check_compatibility, :validate => :boolean, :default => false
-  config :register_schema, :validate => :boolean, :default => false
-  config :binary_encoded, :validate => :boolean, :default => false
 
   public
   def register
     @client = SchemaRegistry::Client.new(endpoint, username, password)
     @schemas = Hash.new
-    @write_schema_id = nil
   end
 
   def get_schema(schema_id)
-    unless @schemas.has_key?(schema_id)
+    if !@schemas.has_key?(schema_id)
       @schemas[schema_id] = Avro::Schema.parse(@client.schema(schema_id))
     end
     @schemas[schema_id]
-  end
-
-  def load_schema_json()
-    if @schema_uri
-      open(@schema_uri).read
-    elsif @schema_string
-      @schema_string
-    else
-      @logger.error('you must supply a schema_uri or schema_string in the config')
-    end
-  end
-
-  def get_write_schema_id()
-    # If schema id is passed, just use that
-    if @schema_id
-      @schema_id
-
-    else
-      # subject_name is required
-      if @subject_name == nil
-        @logger.error('requires a subject_name')
-      else
-        subject = @client.subject(@subject_name)
-
-        # If schema_version, load from subject API
-        if @schema_version != nil
-          schema = subject.version(@schema_version)
-
-        # Otherwise, load schema json and check with registry
-        else
-          schema_json = load_schema_json
-
-          # If not compatible, raise error
-          if @check_compatibility
-            unless subject.compatible?(schema_json)
-              @logger.error('the schema json is not compatible with the subject. you should fix your schema or change the compatibility level.')
-            end
-          end
-
-          if @register_schema
-            subject.register_schema(schema_json) unless subject.schema_registered?(schema_json)
-          end
-
-          schema = subject.verify_schema(schema_json)
-        end
-
-        schema.id
-      end
-    end
   end
 
   public
@@ -156,7 +74,7 @@ class LogStash::Codecs::AvroSchemaRegistry < LogStash::Codecs::Base
     if data.length < 5
       @logger.error('message is too small to decode')
     else
-      datum = StringIO.new(Base64.strict_decode64(data)) rescue StringIO.new(data)
+      datum = StringIO.new(data)
       magic_byte, schema_id = datum.read(5).unpack("cI>")
       if magic_byte != MAGIC_BYTE
         @logger.error('message does not start with magic byte')
@@ -171,20 +89,13 @@ class LogStash::Codecs::AvroSchemaRegistry < LogStash::Codecs::Base
 
   public
   def encode(event)
-    @write_schema_id ||= get_write_schema_id
-    schema = get_schema(@write_schema_id)
+    schema = get_schema(@schema_id)
     dw = Avro::IO::DatumWriter.new(schema)
     buffer = StringIO.new
     buffer.write(MAGIC_BYTE.chr)
-    buffer.write([@write_schema_id].pack("I>"))
+    buffer.write([schema_id].pack("I>"))
     encoder = Avro::IO::BinaryEncoder.new(buffer)
-    eh = event.to_hash
-    eh.delete_if { |key, _| EXCLUDE_ALWAYS.include? key }
-    dw.write(eh, encoder)
-    if @binary_encoded
-       @on_event.call(event, buffer.string.to_java_bytes)
-    else
-       @on_event.call(event, Base64.strict_encode64(buffer.string))
-    end
+    dw.write(event.to_hash, encoder)
+    @on_event.call(event, buffer.string.to_java_bytes)
   end
 end

--- a/lib/logstash/codecs/avro_schema_registry.rb
+++ b/lib/logstash/codecs/avro_schema_registry.rb
@@ -1,5 +1,6 @@
 # encoding: utf-8
 require "avro"
+require "open-uri"
 require "schema_registry"
 require "schema_registry/client"
 require "logstash/codecs/base"
@@ -7,6 +8,7 @@ require "logstash/namespace"
 require "logstash/event"
 require "logstash/timestamp"
 require "logstash/util"
+require "base64"
 
 MAGIC_BYTE = 0
 
@@ -16,25 +18,37 @@ MAGIC_BYTE = 0
 # Avro datums, as well as deserializing Avro datums into
 # Logstash events.
 #
-# ==== Encoding
 #
-# This codec currently does not encode. This might be added later.
-#
-#
-# ==== Decoding
+# ==== Decoding (input)
 #
 # This codec is for deserializing individual Avro records. It looks up
 # the associated avro schema from a Confluent schema registry.
 # (https://github.com/confluentinc/schema-registry)
 #
+# When this codec is used on the input, only the ``endpoint`` option is required.
+#
+# ==== Encoding (output)
+#
+# This codec uses the Confluent schema registry to register a schema and
+# encode the data in Avro using schema_id lookups.
+#
+# You can pass several options:
+# - ``endpoint`` is always required.
+# - If ``schema_id`` is provided, no other options are required.
+# - Otherwise, ``subject_name`` is required.
+# - If ``schema_version`` is provided, the schema will be looked up in the registry.
+# - Otherwise, a JSON schema is loaded from either ``schema_uri``, or ``schema_string``
+# - If ``check_compatibility`` is true, always check compatibility.
+# - If ``register_schema`` is true, register the JSON schema if it does not exist.
 #
 # ==== Usage
-# Example usage with Kafka input.
+# Example usage with Kafka input and output.
 #
 # [source,ruby]
 # ----------------------------------
 # input {
 #   kafka {
+#     ...
 #     codec => avro_schema_registry {
 #       endpoint => "http://schemas.example.com"
 #     }
@@ -44,29 +58,97 @@ MAGIC_BYTE = 0
 #   ...
 # }
 # output {
-#   ...
+#   kafka {
+#     ...
+#     codec => avro_schema_registry {
+#       endpoint => "http://schemas.example.com"
+#       subject_name => "my_kafka_subject_name"
+#       schema_uri => "/app/my_kafka_subject.avsc"
+#       register_schema => true
+#     }
+#   }
 # }
 # ----------------------------------
 class LogStash::Codecs::AvroSchemaRegistry < LogStash::Codecs::Base
   config_name "avro_schema_registry"
+  
+  EXCLUDE_ALWAYS = [ "@timestamp", "@version" ]
 
   # schema registry endpoint and credentials
   config :endpoint, :validate => :string, :required => true
   config :username, :validate => :string, :default => nil
   config :password, :validate => :string, :default => nil
+
   config :schema_id, :validate => :number, :default => nil
+  config :subject_name, :validate => :string, :default => nil
+  config :schema_version, :validate => :number, :default => nil
+  config :schema_uri, :validate => :string, :default => nil
+  config :schema_string, :validate => :string, :default => nil
+  config :check_compatibility, :validate => :boolean, :default => false
+  config :register_schema, :validate => :boolean, :default => false
+  config :binary_encoded, :validate => :boolean, :default => false
 
   public
   def register
     @client = SchemaRegistry::Client.new(endpoint, username, password)
     @schemas = Hash.new
+    @write_schema_id = nil
   end
 
   def get_schema(schema_id)
-    if !@schemas.has_key?(schema_id)
+    unless @schemas.has_key?(schema_id)
       @schemas[schema_id] = Avro::Schema.parse(@client.schema(schema_id))
     end
     @schemas[schema_id]
+  end
+
+  def load_schema_json()
+    if @schema_uri
+      open(@schema_uri).read
+    elsif @schema_string
+      @schema_string
+    else
+      @logger.error('you must supply a schema_uri or schema_string in the config')
+    end
+  end
+
+  def get_write_schema_id()
+    # If schema id is passed, just use that
+    if @schema_id
+      @schema_id
+
+    else
+      # subject_name is required
+      if @subject_name == nil
+        @logger.error('requires a subject_name')
+      else
+        subject = @client.subject(@subject_name)
+
+        # If schema_version, load from subject API
+        if @schema_version != nil
+          schema = subject.version(@schema_version)
+
+        # Otherwise, load schema json and check with registry
+        else
+          schema_json = load_schema_json
+
+          # If not compatible, raise error
+          if @check_compatibility
+            unless subject.compatible?(schema_json)
+              @logger.error('the schema json is not compatible with the subject. you should fix your schema or change the compatibility level.')
+            end
+          end
+
+          if @register_schema
+            subject.register_schema(schema_json) unless subject.schema_registered?(schema_json)
+          end
+
+          schema = subject.verify_schema(schema_json)
+        end
+
+        schema.id
+      end
+    end
   end
 
   public
@@ -74,7 +156,7 @@ class LogStash::Codecs::AvroSchemaRegistry < LogStash::Codecs::Base
     if data.length < 5
       @logger.error('message is too small to decode')
     else
-      datum = StringIO.new(data)
+      datum = StringIO.new(Base64.strict_decode64(data)) rescue StringIO.new(data)
       magic_byte, schema_id = datum.read(5).unpack("cI>")
       if magic_byte != MAGIC_BYTE
         @logger.error('message does not start with magic byte')
@@ -89,13 +171,20 @@ class LogStash::Codecs::AvroSchemaRegistry < LogStash::Codecs::Base
 
   public
   def encode(event)
-    schema = get_schema(@schema_id)
+    @write_schema_id ||= get_write_schema_id
+    schema = get_schema(@write_schema_id)
     dw = Avro::IO::DatumWriter.new(schema)
     buffer = StringIO.new
     buffer.write(MAGIC_BYTE.chr)
-    buffer.write([schema_id].pack("I>"))
+    buffer.write([@write_schema_id].pack("I>"))
     encoder = Avro::IO::BinaryEncoder.new(buffer)
-    dw.write(event.to_hash, encoder)
-    @on_event.call(event, buffer.string.to_java_bytes)
+    eh = event.to_hash
+    eh.delete_if { |key, _| EXCLUDE_ALWAYS.include? key }
+    dw.write(eh, encoder)
+    if @binary_encoded
+       @on_event.call(event, buffer.string.to_java_bytes)
+    else
+       @on_event.call(event, Base64.strict_encode64(buffer.string))
+    end
   end
 end

--- a/logstash-codec-avro_schema_registry.gemspec
+++ b/logstash-codec-avro_schema_registry.gemspec
@@ -18,9 +18,9 @@ Gem::Specification.new do |s|
   s.metadata = { "logstash_plugin" => "true", "logstash_group" => "codec" }
 
   # Gem dependencies
-  s.add_runtime_dependency "logstash-core-plugin-api", ">= 1.60", "<= 2.99"
-  s.add_runtime_dependency "logstash-codec-line"
+  s.add_runtime_dependency 'logstash-core-plugin-api', "~> 2.0"
+  s.add_runtime_dependency 'logstash-codec-line'
   s.add_runtime_dependency "avro"  #(Apache 2.0 license)
   s.add_runtime_dependency "schema_registry"  #(MIT license)
-  s.add_development_dependency "logstash-devutils"
+  s.add_development_dependency 'logstash-devutils'
 end

--- a/logstash-codec-avro_schema_registry.gemspec
+++ b/logstash-codec-avro_schema_registry.gemspec
@@ -18,9 +18,9 @@ Gem::Specification.new do |s|
   s.metadata = { "logstash_plugin" => "true", "logstash_group" => "codec" }
 
   # Gem dependencies
-  s.add_runtime_dependency 'logstash-core-plugin-api', "~> 2.0"
-  s.add_runtime_dependency 'logstash-codec-line'
+  s.add_runtime_dependency "logstash-core-plugin-api", ">= 1.60", "<= 2.99"
+  s.add_runtime_dependency "logstash-codec-line"
   s.add_runtime_dependency "avro"  #(Apache 2.0 license)
   s.add_runtime_dependency "schema_registry"  #(MIT license)
-  s.add_development_dependency 'logstash-devutils'
+  s.add_development_dependency "logstash-devutils"
 end


### PR DESCRIPTION
HI @ryananguiano,
finally I have reviewed your encode branch #5. I have found two bugs:
- subject_version config parameter should be schema_version.
- schema_uri config should be validated as string. If validated as uri, it fails with the default "nil" value.
- require base64 to use Base64.

I have also added a binary_encoded config option for the case you want the output to be directly bytes and not Base64 encoded String. (I need that for my use case). 