### PR TITLE
Add the ability to decorate events with schema metadata

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ When this codec is used to decode the input, you may pass the following options:
 - ``username`` - optional.
 - ``password`` - optional.
 - ``tag_on_failure`` - tag events with ``_avroparsefailure`` when decode fails
+- ``decorate_events`` - will add avro schema metadata to the event.
 
 If the input stream is binary encoded, you should use the ``ByteArrayDeserializer``
 in the Kafka input config.

--- a/lib/avro_patches/logical_types/decode_date_as_time_patch.rb
+++ b/lib/avro_patches/logical_types/decode_date_as_time_patch.rb
@@ -1,0 +1,14 @@
+# The avro-patches gem will convert some date-related logical-types in
+# Avro schemas to Ruby Date and Time objects.
+#
+# LogStash has methods to convert certain Ruby classes into JSON
+# values, but it does not support Ruby's Date class. It does support
+# Time (which is used by the timestamp-micros and timestamp-millis
+# logical types), so we convert the Date object to Time here.
+Avro::LogicalTypes::IntDate.class_eval do
+  EPOCH_START = Date.new(1970, 1, 1)
+
+  def self.decode(int)
+    (EPOCH_START + int).to_time.utc
+  end
+end

--- a/lib/logstash/codecs/avro_schema_registry.rb
+++ b/lib/logstash/codecs/avro_schema_registry.rb
@@ -232,7 +232,7 @@ class LogStash::Codecs::AvroSchemaRegistry < LogStash::Codecs::Base
         datum_reader = Avro::IO::DatumReader.new(schema)
         event = LogStash::Event.new(datum_reader.read(decoder))
         if @decorate_events
-          decorate_event(event, schema)
+          decorate_event(event, schema, schema_id)
         end
         yield event
       end
@@ -264,7 +264,8 @@ class LogStash::Codecs::AvroSchemaRegistry < LogStash::Codecs::Base
   end
 
   private
-  def decorate_event(event, schema)
+  def decorate_event(event, schema, schema_id)
+    event.set("[@metadata][avro][schema_id]", schema_id)
     event.set("[@metadata][avro][type]", schema.type)
     if schema.is_a?(Avro::Schema::NamedSchema)
       event.set("[@metadata][avro][name]", schema.name)

--- a/lib/logstash/codecs/avro_schema_registry.rb
+++ b/lib/logstash/codecs/avro_schema_registry.rb
@@ -30,6 +30,7 @@ MAGIC_BYTE = 0
 # - ``username`` - optional.
 # - ``password`` - optional.
 # - ``tag_on_failure`` - tag events with ``_avroparsefailure`` when decode fails
+# - ``decorate_events`` - will add avro schema metadata to the event.
 #
 # If the input stream is binary encoded, you should use the ``ByteArrayDeserializer``
 # in the Kafka input config.
@@ -127,6 +128,7 @@ class LogStash::Codecs::AvroSchemaRegistry < LogStash::Codecs::Base
   config :check_compatibility, :validate => :boolean, :default => false
   config :register_schema, :validate => :boolean, :default => false
   config :binary_encoded, :validate => :boolean, :default => true
+  config :decorate_events, :validate => :boolean, :default => false
 
   # tag events with `_avroparsefailure` when decode fails
   config :tag_on_failure, :validate => :boolean, :default => false
@@ -228,7 +230,11 @@ class LogStash::Codecs::AvroSchemaRegistry < LogStash::Codecs::Base
         schema = get_schema(schema_id)
         decoder = Avro::IO::BinaryDecoder.new(datum)
         datum_reader = Avro::IO::DatumReader.new(schema)
-        yield LogStash::Event.new(datum_reader.read(decoder))
+        event = LogStash::Event.new(datum_reader.read(decoder))
+        if @decorate_events
+          decorate_event(event, schema)
+        end
+        yield event
       end
     end
   rescue => e
@@ -254,6 +260,15 @@ class LogStash::Codecs::AvroSchemaRegistry < LogStash::Codecs::Base
        @on_event.call(event, buffer.string.to_java_bytes)
     else
        @on_event.call(event, Base64.strict_encode64(buffer.string))
+    end
+  end
+
+  private
+  def decorate_event(event, schema)
+    event.set("[@metadata][avro][type]", schema.type)
+    if schema.is_a?(Avro::Schema::NamedSchema)
+      event.set("[@metadata][avro][name]", schema.name)
+      event.set("[@metadata][avro][namespace]", schema.namespace)
     end
   end
 end

--- a/lib/logstash/codecs/avro_schema_registry.rb
+++ b/lib/logstash/codecs/avro_schema_registry.rb
@@ -1,5 +1,6 @@
 # encoding: utf-8
 require "avro"
+require "avro-patches"
 require "open-uri"
 require "schema_registry"
 require "schema_registry/client"

--- a/lib/logstash/codecs/avro_schema_registry.rb
+++ b/lib/logstash/codecs/avro_schema_registry.rb
@@ -1,6 +1,7 @@
 # encoding: utf-8
 require "avro"
 require "avro-patches"
+require "avro_patches/logical_types/decode_date_as_time_patch"
 require "open-uri"
 require "schema_registry"
 require "schema_registry/client"

--- a/logstash-codec-avro_schema_registry.gemspec
+++ b/logstash-codec-avro_schema_registry.gemspec
@@ -21,6 +21,7 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency "logstash-core-plugin-api", ">= 1.60", "<= 2.99"
   s.add_runtime_dependency "logstash-codec-line"
   s.add_runtime_dependency "avro"  #(Apache 2.0 license)
+  s.add_runtime_dependency "avro-patches", ">= 0.3"
   s.add_runtime_dependency "schema_registry", ">= 0.1.0" #(MIT license)
   s.add_development_dependency "logstash-devutils"
 end


### PR DESCRIPTION
Thanks for this plugin.

I needed to access the name and namespace of the schema downstream from the codec. This adds a config option to decorate the events with some metadata. Feedback is appreciated.