### PR TITLE
Support TLS authentication for schema registry

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,6 @@
 *.gem
+vendor/
+.ruby-version
 Gemfile.lock
 .bundle
 .idea/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 1.1.0
+ - Add support for client side TLS auth to schema registry
+
 ## 1.0.0
  - Add encode capability
  - Try base64 decode/encode on input/output

--- a/README.md
+++ b/README.md
@@ -42,8 +42,7 @@ When this codec is used to encode, you may pass the following options:
 - ``schema_string`` - required when there is no ``schema_id``, ``schema_version`` or ``schema_uri``
 - ``check_compatibility`` - will check schema compatibility before encoding.
 - ``register_schema`` - will register the JSON schema if it does not exist.
-- ``binary_encoded`` - will output the encoded event as a ByteArray. 
-  Requires the ``ByteArraySerializer`` to be set in the Kafka output config.
+- ``binary_encoded`` - will output the encoded event as a ByteArray. Requires the ``ByteArraySerializer`` to be set in the Kafka output config.
 - ``client_certificate`` -  Client TLS certificate for mutual TLS
 - ``client_key`` -  Client TLS key for mutual TLS
 - ``ca_certificate`` -  CA Certificate

--- a/README.md
+++ b/README.md
@@ -42,7 +42,8 @@ When this codec is used to encode, you may pass the following options:
 - ``schema_string`` - required when there is no ``schema_id``, ``schema_version`` or ``schema_uri``
 - ``check_compatibility`` - will check schema compatibility before encoding.
 - ``register_schema`` - will register the JSON schema if it does not exist.
-- ``binary_encoded`` - will output the encoded event as a ByteArray. Requires the ``ByteArraySerializer`` to be set in the Kafka output config.
+- ``binary_encoded`` - will output the encoded event as a ByteArray.
+Requires the ``ByteArraySerializer`` to be set in the Kafka output config.
 - ``client_certificate`` -  Client TLS certificate for mutual TLS
 - ``client_key`` -  Client TLS key for mutual TLS
 - ``ca_certificate`` -  CA Certificate

--- a/README.md
+++ b/README.md
@@ -42,8 +42,14 @@ When this codec is used to encode, you may pass the following options:
 - ``schema_string`` - required when there is no ``schema_id``, ``schema_version`` or ``schema_uri``
 - ``check_compatibility`` - will check schema compatibility before encoding.
 - ``register_schema`` - will register the JSON schema if it does not exist.
-- ``binary_encoded`` - will output the encoded event as a ByteArray.
+- ``binary_encoded`` - will output the encoded event as a ByteArray. 
   Requires the ``ByteArraySerializer`` to be set in the Kafka output config.
+- ``client_certificate`` -  Client TLS certificate for mutual TLS
+- ``client_key`` -  Client TLS key for mutual TLS
+- ``ca_certificate`` -  CA Certificate
+- ``verify_mode`` -  SSL Verify modes.  Valid options are `verify_none`, `verify_peer`,  `verify_client_once` , and `verify_fail_if_no_peer_cert`.  Default is `verify_peer`
+
+  
 
 ## Usage
 
@@ -87,6 +93,26 @@ output {
       binary_encoded => true
     }
     value_serializer => "org.apache.kafka.common.serialization.ByteArraySerializer"
+  }
+}
+```
+
+### Using signed certificate for registry authentication
+
+```
+output {
+  kafka {
+    ...
+    codec => avro_schema_registry {
+      endpoint => "http://schemas.example.com"
+      schema_id => 47
+      binary_encoded => true
+    }
+    value_serializer => "org.apache.kafka.common.serialization.ByteArraySerializer"
+    client_key          => "./client.key"
+    client_certificate  => "./client.crt"
+    ca_certificate      => "./ca.pem"
+    verify_mode         => "verify_peer"
   }
 }
 ```

--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ When this codec is used to encode, you may pass the following options:
 - ``check_compatibility`` - will check schema compatibility before encoding.
 - ``register_schema`` - will register the JSON schema if it does not exist.
 - ``binary_encoded`` - will output the encoded event as a ByteArray.
-Requires the ``ByteArraySerializer`` to be set in the Kafka output config.
+  Requires the ``ByteArraySerializer`` to be set in the Kafka output config.
 - ``client_certificate`` -  Client TLS certificate for mutual TLS
 - ``client_key`` -  Client TLS key for mutual TLS
 - ``ca_certificate`` -  CA Certificate

--- a/lib/logstash/codecs/avro_schema_registry.rb
+++ b/lib/logstash/codecs/avro_schema_registry.rb
@@ -118,9 +118,25 @@ class LogStash::Codecs::AvroSchemaRegistry < LogStash::Codecs::Base
   config :register_schema, :validate => :boolean, :default => false
   config :binary_encoded, :validate => :boolean, :default => false
 
+  config :client_certificate, :validate => :string, :default => nil
+  config :client_key, :validate => :string, :default => nil
+  config :ca_certificate, :validate => :string, :default => nil
+  config :verify_mode, :validate => :string, :default => 'verify_peer'
+  
   public
   def register
-    @client = SchemaRegistry::Client.new(endpoint, username, password)
+
+    @client = if client_certificate != nil
+      SchemaRegistry::Client.new(endpoint, username, password, SchemaRegistry::Client.connection_options(
+        client_certificate: client_certificate,
+        client_key: client_key,
+        ca_certificate: ca_certificate,
+        verify_mode: verify_mode
+      ))
+    else
+      SchemaRegistry::Client.new(endpoint, username, password)
+    end
+
     @schemas = Hash.new
     @write_schema_id = nil
   end

--- a/logstash-codec-avro_schema_registry.gemspec
+++ b/logstash-codec-avro_schema_registry.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |s|
   s.name          = 'logstash-codec-avro_schema_registry'
-  s.version       = '1.0.0'
+  s.version       = '1.1.0'
   s.licenses      = ['Apache License (2.0)']
   s.summary         = "Encode and decode avro formatted data from a Confluent schema registry"
   s.description     = "Encode and decode avro formatted data from a Confluent schema registry"

--- a/logstash-codec-avro_schema_registry.gemspec
+++ b/logstash-codec-avro_schema_registry.gemspec
@@ -21,6 +21,6 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency "logstash-core-plugin-api", ">= 1.60", "<= 2.99"
   s.add_runtime_dependency "logstash-codec-line"
   s.add_runtime_dependency "avro"  #(Apache 2.0 license)
-  s.add_runtime_dependency "schema_registry"  #(MIT license)
+  s.add_runtime_dependency "schema_registry", ">= 0.1.0" #(MIT license)
   s.add_development_dependency "logstash-devutils"
 end


### PR DESCRIPTION
I have implemented optional support for using TLS authentication for authentication w/ the Schema registry.   This is dependent on my recent PR in schema_registry ( https://github.com/wvanbergen/schema_registry/pull/4 ) 