### PR TITLE
Continue on error

### DIFF
--- a/logstash-codec-avro_schema_registry.gemspec
+++ b/logstash-codec-avro_schema_registry.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |s|
   s.name          = 'logstash-codec-avro_schema_registry'
-  s.version       = '1.1.0'
+  s.version       = '1.1.1'
   s.licenses      = ['Apache License (2.0)']
   s.summary         = "Encode and decode avro formatted data from a Confluent schema registry"
   s.description     = "Encode and decode avro formatted data from a Confluent schema registry"


### PR DESCRIPTION
We had an issue where processes putting avro encoded messages onto the kafka topic were doing so with valid avro, but an invalid schema id. This should not happen, but it did happen. Anyway, this is what we did to get around it, by logging the message we can track down the process which created it, but not crash logstash (which is the current behavior).