### PR TITLE
Fix to_java_bytes error on logstash 6.x

### DIFF
--- a/lib/logstash/codecs/avro_schema_registry.rb
+++ b/lib/logstash/codecs/avro_schema_registry.rb
@@ -251,7 +251,7 @@ class LogStash::Codecs::AvroSchemaRegistry < LogStash::Codecs::Base
     encoder = Avro::IO::BinaryEncoder.new(buffer)
     dw.write(clean_event(event), encoder)
     if @binary_encoded
-       @on_event.call(event, buffer.string.to_java_bytes)
+       @on_event.call(event, buffer.string)
     else
        @on_event.call(event, Base64.strict_encode64(buffer.string))
     end


### PR DESCRIPTION
Remove to_java_bytes patch since now it is done in logstash-output-kafka after PR #126 (fix byte array value_serializer)

[https://github.com/logstash-plugins/logstash-output-kafka/pull/162](https://github.com/logstash-plugins/logstash-output-kafka/pull/162)