### PR TITLE
Add decorate_events configuration option

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Logstash Codec - Avro Schema Registry
 
-### v1.2.0
+### v1.3.0
 
 This plugin is used to serialize Logstash events as
 Avro datums, as well as deserializing Avro datums into

--- a/README.md
+++ b/README.md
@@ -23,6 +23,17 @@ When this codec is used to decode the input, you may pass the following options:
 - ``username`` - optional.
 - ``password`` - optional.
 - ``tag_on_failure`` - tag events with ``_avroparsefailure`` when decode fails
+- `decorate_events` - will add avro schema metadata to the event.
+```
+"@metadata" => {
+  "avro" => {
+    "name" => "schema",
+    "namespace" => "namespace",
+    "type" => "record",
+    "schema_id" => 1799
+  }
+}
+```
 
 If the input stream is binary encoded, you should use the ``ByteArrayDeserializer``
 in the Kafka input config.

--- a/logstash-codec-avro_schema_registry.gemspec
+++ b/logstash-codec-avro_schema_registry.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |s|
   s.name          = 'logstash-codec-avro_schema_registry'
-  s.version       = '1.2.0'
+  s.version       = '1.3.0'
   s.licenses      = ['Apache License (2.0)']
   s.summary         = "Encode and decode avro formatted data from a Confluent schema registry"
   s.description     = "Encode and decode avro formatted data from a Confluent schema registry"


### PR DESCRIPTION
This is a rerun of another PR that was closed - https://github.com/revpoint/logstash-codec-avro_schema_registry/pull/12

Adds the information about the schema used to decode the message to the `@metadata` field:

```
"@metadata" => {
  "avro" => {
    "name" => "schema",
    "namespace" => "namespace",
    "type" => "record",
    "schema_id" => 1799
  }
}
```